### PR TITLE
A slight sprinkling of optimization.

### DIFF
--- a/AnimatedGifConsole.csproj
+++ b/AnimatedGifConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/AnimatedGifConsole.csproj
+++ b/AnimatedGifConsole.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
-      <PackageReference Include="Spectre.Console" Version="0.41.0" />
-      <PackageReference Include="Spectre.Console.ImageSharp" Version="0.41.0" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+      <PackageReference Include="Spectre.Console" Version="0.42.0" />
+      <PackageReference Include="Spectre.Console.ImageSharp" Version="0.42.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Program.cs
+++ b/Program.cs
@@ -30,10 +30,7 @@ await AnsiConsole.Live(Text.Empty)
                 ctx.UpdateTarget(canvasImage);
 
                 // FrameDelay is measured in 1/100th second.
-                // Let's round down since we're encoding per frame.
-                //
-                // Ideally we would only do this loop + save once and maintain a list of frames
-                // that we dispose of at the end of the operations.
+                // Let's half the delay since we're encoding per frame.
                 await Task.Delay(TimeSpan.FromMilliseconds(delay * 5), cts.Token);
             }
         }


### PR DESCRIPTION
- Updated target framework + references.
- Used built in APIs for frame cloning.

Things to note. For performance it might be worth only looping through the frames once then maintaining a `List<(int Delay, byte[] Data)>` for future iterations to avoid cloning an encoding each frame. I've kept things very simple though as it's working well on my laptop.